### PR TITLE
fix firebase hosting rewrites

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,12 @@
     "template": "remoteconfig.template.json"
   },
   "hosting": {
-    "public": "build"
+    "public": "build",
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
   }
 }


### PR DESCRIPTION
check out [breadcrumbs.wumpler.com](https://breadcrumbs.wumpler.com) hehe

(this PR specifically is saying that links like [breadcrumbs.wumpler.com/nik](https://breadcrumbs.wumpler.com) won't go to a Firebase 404, but will be handled by React Router)